### PR TITLE
allow project to redefine rubocop settings

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,5 +1,5 @@
 [
-  { "keys": ["ctrl+alt+c"], "command": "rubocop_check_single_file" },
-  { "keys": ["ctrl+shift+c"], "command": "rubocop_check_project" },
-  { "keys": ["ctrl+shift+v"], "command": "rubocop_check_file_folder" }
+  // { "keys": ["ctrl+alt+c"], "command": "rubocop_check_single_file" },
+  // { "keys": ["ctrl+shift+c"], "command": "rubocop_check_project" },
+  // { "keys": ["ctrl+shift+v"], "command": "rubocop_check_file_folder" }
 ]

--- a/file_tools.py
+++ b/file_tools.py
@@ -25,6 +25,9 @@ class FileTools(object):
       return False
     syntax_file = view.settings().get('syntax')
 
+    if syntax_file == None:
+      return False
+
     for syntax in RUBY_SYNTAX_FILES:
       if syntax_file.endswith(syntax):
         return True

--- a/rubocop_listener.py
+++ b/rubocop_listener.py
@@ -140,6 +140,6 @@ class RubocopEventListener(sublime_plugin.EventListener):
       first_sel = curr_sel[0]
       row, col = view.rowcol(first_sel.begin())
       if row in view_dict.keys():
-        sublime.status_message('RuboCop: {0}'.format(view_dict[row]))
+        view.set_status('rubocop', 'RuboCop: {0}'.format(view_dict[row]))
       else:
-        sublime.status_message('')
+        view.set_status('rubocop', '')

--- a/rubocop_listener.py
+++ b/rubocop_listener.py
@@ -75,16 +75,19 @@ class RubocopEventListener(sublime_plugin.EventListener):
     view.add_regions(REGIONS_ID, lines, 'keyword', icon,
         REGIONS_OPTIONS_BITS)
 
-  def run_rubocop(self, path):
+  def run_rubocop(self, view):
     s = sublime.load_settings(SETTINGS_FILE)
-    use_rvm = s.get('check_for_rvm')
-    use_rbenv = s.get('check_for_rbenv')
-    cmd = s.get('rubocop_command')
-    rvm_path = s.get('rvm_auto_ruby_path')
-    rbenv_path = s.get('rbenv_path')
-    cfg_file = s.get('rubocop_config_file')
+
+    use_rvm = view.settings().get('check_for_rvm', s.get('check_for_rvm'))
+    use_rbenv = view.settings().get('check_for_rbenv', s.get('check_for_rbenv'))
+    cmd = view.settings().get('rubocop_command', s.get('rubocop_command'))
+    rvm_path = view.settings().get('rvm_auto_ruby_path', s.get('rvm_auto_ruby_path'))
+    rbenv_path = view.settings().get('rbenv_path', s.get('rbenv_path'))
+    cfg_file = view.settings().get('rubocop_config_file', s.get('rubocop_config_file'))
+
     if cfg_file:
       cfg_file = FileTools.quote(cfg_file)
+
     runner = RubocopRunner(
       {
         'use_rbenv': use_rbenv,
@@ -97,13 +100,14 @@ class RubocopEventListener(sublime_plugin.EventListener):
         'is_st2': sublime.version() < '3000'
       }
     )
-    output = runner.run([path], ['--format', 'emacs']).splitlines()
+    output = runner.run([view.file_name()], ['--format', 'emacs']).splitlines()
+
     return output
 
   def mark_issues(self, view, mark):
     self.clear_marks(view)
     if mark:
-      results = self.run_rubocop(view.file_name())
+      results = self.run_rubocop(view)
       self.set_marks_by_results(view, results)
 
   def do_in_file_check(self, view):

--- a/rubocop_listener.py
+++ b/rubocop_listener.py
@@ -84,6 +84,7 @@ class RubocopEventListener(sublime_plugin.EventListener):
     rvm_path = view.settings().get('rvm_auto_ruby_path', s.get('rvm_auto_ruby_path'))
     rbenv_path = view.settings().get('rbenv_path', s.get('rbenv_path'))
     cfg_file = view.settings().get('rubocop_config_file', s.get('rubocop_config_file'))
+    chdir = view.settings().get('rubocop_chdir', s.get('rubocop_chdir'))
 
     if cfg_file:
       cfg_file = FileTools.quote(cfg_file)
@@ -97,6 +98,7 @@ class RubocopEventListener(sublime_plugin.EventListener):
         'rbenv_path': rbenv_path,
         'on_windows': sublime.platform() == 'windows',
         'rubocop_config_file': cfg_file,
+        'chdir': chdir,
         'is_st2': sublime.version() < '3000'
       }
     )

--- a/rubocop_runner.py
+++ b/rubocop_runner.py
@@ -14,6 +14,7 @@ class RubocopRunner(object):
     self.is_st2 = False
     self.custom_rubocop_cmd = ''
     self.rubocop_config_file = ''
+    self.chdir = None
     vars(self).update(args)
 
   def set_default_paths(self):
@@ -46,7 +47,7 @@ class RubocopRunner(object):
       use_shell = True
     # TODO: Add "cwd" parameter (working dir)
     p = subprocess.Popen(call_list, shell=use_shell,
-      stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+      stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=self.chdir)
     out, err = p.communicate()
     return out
 


### PR DESCRIPTION
Hey!

It would be great if user would be able to define rubocop settings on per-project base (when using embedded projects functionality of sublime). In that case user can define something like:

```
{
  "folders": [
    {
      "path": "/home/leo/src/myproject",
    }
  ],
  "settings": {
    "rubocop_config_file": "/home/leo/src/myproject/.rubocop.yml",
  }
}
```

In project configuration and use custom rubocop settings file or command for this project.

Also `rubocop_chdir` option added to configuration:

```
{
  "folders": [
    {
      "path": "/home/leo/src/myproject",
    }
  ],
  "settings": {
    "rubocop_command": "bundle exec rubocop",
    "rubocop_chdir": "/home/leo/src/myproject",
  }
}
```