### PR TITLE
fix file_regex to present column number and error message to exec com…

### DIFF
--- a/rubocop_command.py
+++ b/rubocop_command.py
@@ -89,7 +89,7 @@ class RubocopCommand(sublime_plugin.TextCommand):
       'cmd': command,
       'shell': True,
       'working_dir': working_dir,
-      'file_regex': r"^(.*):(\d*):\d*: .: .*$",
+      'file_regex': r"^(.*):(\d*):(\d*): (.: .*$)"
     })
 
 # --------- General rubocop commands -------------


### PR DESCRIPTION
Hi, thank you for such nice package. I improved rubocop message appearance here, so please merge into your master.
https://gist.github.com/Samemura/e51422a680ef61dd33c4f37f1cd41ddf

Background:
First I used this package, I realized rubocop message on file view has unnecessary information like file path and line number which is already clear in file view. 
If it is removed, then your package will be more great to see message easily.

Debug condition:
Sublime Text 3 build 3126
OS X El Capitan 10.11.6