### PR TITLE
Fix quotes in example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -44,10 +44,10 @@ To use rbenv, for example, go to _Preferences > Package Settings > Rubocop > Set
 
 ```
 {
-  “check_for_rvm”: false,
-  “check_for_rbenv”: true,
+  "check_for_rvm": false,
+  "check_for_rbenv": true,
   // In case you need a custom rbenv path
-  “rbenv_path”: “~/.rbenv/bin/rbenv”,
+  "rbenv_path": "~/.rbenv/bin/rbenv",
 }
 ```
 


### PR DESCRIPTION
Use `"` instead of `”`. With incorrect quotes it won't work.
<img width="612" alt="screenshot 2018-11-26 at 13 24 55" src="https://user-images.githubusercontent.com/7052048/49013936-ad45b480-f17e-11e8-9ace-481d36219228.png">