### PR TITLE
Ensure global exclusions are honored. Add --force-exclusion

### DIFF
--- a/rubocop_listener.py
+++ b/rubocop_listener.py
@@ -111,7 +111,7 @@ class RubocopEventListener(sublime_plugin.EventListener):
         'is_st2': sublime.version() < '3000'
       }
     )
-    output = runner.run([view.file_name()], ['--format', 'emacs']).splitlines()
+    output = runner.run([view.file_name()], ['--format', 'emacs', '--force-exclusion']).splitlines()
 
     return output
 


### PR DESCRIPTION
Rubocop by default ignores global exclusions if the file path has been explicitly provided, this is not the behaviour we want for editor linting.

The `--force-exclusion` option was added just so that files given on the command line could be excluded by configuration.

fix issues #25 and #28 