### PR TITLE
Use current_project_folder when running rubocop

### DIFF
--- a/rubocop_listener.py
+++ b/rubocop_listener.py
@@ -8,10 +8,12 @@ if sublime.version() >= '3000':
   from RuboCop.file_tools import FileTools
   from RuboCop.rubocop_runner import RubocopRunner
   from RuboCop.constants import *
+  from RuboCop.rubocop_plugin import RubocopPlugin
 else:
   from file_tools import FileTools
   from rubocop_runner import RubocopRunner
   from constants import *
+  from rubocop_plugin import RubocopPlugin
 
 # Event listener to provide on the fly checks when saving a ruby file.
 class RubocopEventListener(sublime_plugin.EventListener):
@@ -93,7 +95,7 @@ class RubocopEventListener(sublime_plugin.EventListener):
     rvm_path = view.settings().get('rvm_auto_ruby_path', s.get('rvm_auto_ruby_path'))
     rbenv_path = view.settings().get('rbenv_path', s.get('rbenv_path'))
     cfg_file = view.settings().get('rubocop_config_file', s.get('rubocop_config_file'))
-    chdir = view.settings().get('rubocop_chdir', s.get('rubocop_chdir'))
+    chdir = view.settings().get('rubocop_chdir', s.get('rubocop_chdir')) or RubocopPlugin.current_project_folder()
 
     if cfg_file:
       cfg_file = FileTools.quote(cfg_file)
@@ -105,7 +107,7 @@ class RubocopEventListener(sublime_plugin.EventListener):
         'custom_rubocop_cmd': cmd,
         'rvm_auto_ruby_path': rvm_path,
         'rbenv_path': rbenv_path,
-        'on_windows': sublime.platform() == 'windows',
+        'on_windows': RubocopPlugin.on_windows(),
         'rubocop_config_file': cfg_file,
         'chdir': chdir,
         'is_st2': sublime.version() < '3000'

--- a/rubocop_plugin.py
+++ b/rubocop_plugin.py
@@ -1,0 +1,35 @@
+import sublime
+import os
+
+class RubocopPlugin:
+
+  @staticmethod
+  def on_windows():
+    return sublime.platform() == 'windows'
+
+  @staticmethod
+  def is_st2():
+    return int(sublime.version()) < 3000
+
+  @staticmethod
+  def is_st3():
+    return int(sublime.version()) >= 3000
+
+  @staticmethod
+  def current_project_folder():
+    if RubocopPlugin.is_st3():
+      project = sublime.active_window().project_data()
+      project_base_path = os.path.dirname(sublime.active_window().project_file_name() or '')
+      if not (project is None):
+        if 'folders' in project:
+          folders = project['folders']
+          if len(folders) > 0:
+            first_folder = folders[0]
+            if 'path' in first_folder:
+              path = first_folder['path']
+              return (path if os.path.isabs(path) else os.path.join(project_base_path, path)) or ''
+    else:
+      folders = sublime.active_window().folders()
+      if (not (folders is None)) and (len(folders) > 0):
+        return folders[0]
+    return ''


### PR DESCRIPTION
I've added a few lines of code to log the out and err strings from the rubocop process if the process exit code is something else than 0 or 1. This should give some clues about why some commands have no result.

I have also set the `chdir` options to the `current_project_folder` when running rubocop. This makes sure that if you have a per project `.rubocop.yml` it will be picked up.